### PR TITLE
Added Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:alpine
+
+WORKDIR /adaptor
+ADD . .
+
+ENV PORT=80
+
+RUN npm install
+ENTRYPOINT ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chainlink CoinMarketCap External Adapter
 
-Adapter for use on Google Cloud Platform or AWS Lambda. Upload Zip and use trigger URL as bridge endpoint.
+Adapter for use on Google Cloud Platform, AWS Lambda or Docker. Upload Zip and use trigger URL as bridge endpoint.
 
 ## Install
 
@@ -20,6 +20,16 @@ Create a cloud function in GCP or Lambda, and set the handler function according
 * AWS: `handler`
 
 **REMEMBER TO** set the environment variable `API_KEY` to your [CoinMarketCap API Key](https://pro.coinmarketcap.com/)!
+
+## Docker
+```bash
+docker build . -t cmcadaptor
+docker run -d \
+    --name cmcadaptor \
+    -p 80:80 \
+    -e PORT=80 \
+    cmcadaptor
+```
 
 ## Test Cases (GCP/AWS test events)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ docker run -d \
     --name cmcadaptor \
     -p 80:80 \
     -e PORT=80 \
+    -e API_KEY=<YOUR CMC API KEY> \
     cmcadaptor
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "homepage": "https://github.com/OracleFinder/CMCExternalAdapter#readme",
   "dependencies": {
+    "body-parser": "^1.18.3",
+    "express": "^4.16.3",
     "request": "^2.88.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const adaptor = require('./index');
+
+const app = express();
+app.use(bodyParser.json());
+
+app.post('/', function(req, res) {
+  adaptor.gcpservice(req, res)
+});
+
+let listener = app.listen(process.env.PORT, function() {
+  console.log("CMC External Adaptor listening on", listener.address().address + listener.address().port);
+});


### PR DESCRIPTION
Server listens for POST requests at root `/`

README has steps for running it locally, but I didn't know if you'd want to set-up an automated build on Docker Hub so it can be pulled down by people without building it first.

Open to any feedback on if you want it done differently.